### PR TITLE
Bootstrap sticky footer extra space fix

### DIFF
--- a/application/views/_footer.php
+++ b/application/views/_footer.php
@@ -3,6 +3,7 @@
         <p class="text-muted">
             <span class="glyphicon glyphicon-copyright-mark"></span>
              2015
-            <a href="https://github.com/Ctrl-Alt-Believe">Ctrl-Alt-Believe</a></p>
+            <a href="https://github.com/Ctrl-Alt-Believe">Ctrl-Alt-Believe</a>
+        </p>
     </div>
 </footer>

--- a/application/views/_template.php
+++ b/application/views/_template.php
@@ -13,17 +13,13 @@
 <body>
 
     <!-- Header -->
-    <div class="row">
-        {header}
-    </div>
+    {header}
 
     <!-- Content -->
     {content}
 
     <!-- Footer -->
-    <div class="row">
-        {footer}
-    </div>
+    {footer}
 
     <script type="javascript" src="/assets/vendor/bootstrap/js/bootstrap.min.js"></script>
     <script type="javascript" src="/assets/vendor/jquery/jquery-2.1.3.min.js"></script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,7 +7,7 @@
 }
 
 .container {
-    max-width: 960px
+    /*max-width: 960px*/
 }
 
 #page-header {
@@ -39,7 +39,7 @@ html {
 }
 body {
     /* Margin bottom by footer height */
-    margin-bottom: 60px;
+    margin-bottom: 80px;
 }
 .footer {
     position: absolute;


### PR DESCRIPTION
Fixed bootstrap implementation which fixes the white space on the right of the page. Site is more responsive now and mobile users can no longer scroll right.
